### PR TITLE
fix ports for Docker Swarm in security group

### DIFF
--- a/roles/provisioning/defaults/main.yml
+++ b/roles/provisioning/defaults/main.yml
@@ -2,8 +2,12 @@
 # file: roles/provisioning/defaults/main.yml
 # if not overridden in inventory or as a parameter, this is the value that will be used
 ssh_port: 22
-swarm_manager_port: 2377
-flanel_overlay_network_port: 8472
+# tcp
+swarm_cluster_management_port: 2377
+# tcp and udp
+swarm_node_communication_port: 7946
+# tcp and udp
+swarm_overlay_traffic_port: 4789
 swarm_num_managers: 1
 swarm_num_workers: 3
 volume_size: 100

--- a/roles/provisioning/tasks/create_secgroup.yml
+++ b/roles/provisioning/tasks/create_secgroup.yml
@@ -12,25 +12,43 @@
           to_port: "{{ ssh_port }}"
           cidr_ip: 0.0.0.0/0
         - proto: tcp
-          from_port: "{{ swarm_manager_port }}"
-          to_port: "{{ swarm_manager_port }}"
+          from_port: "{{ swarm_cluster_management_port }}"
+          to_port: "{{ swarm_cluster_management_port}}"
           group_name: "{{ swarm_security_group_name }}"
-        - proto: -1
+        - proto: tcp
+          from_port: "{{ swarm_node_communication_port }}"
+          to_port: "{{ swarm_node_communication_port }}"
+          group_name: "{{ swarm_security_group_name }}"
+        - proto: udp
+          from_port: "{{ swarm_node_communication_port }}"
+          to_port: "{{ swarm_node_communication_port }}"
+          group_name: "{{ swarm_security_group_name }}"
+        - proto: tcp
+          from_port: "{{ swarm_overlay_traffic_port }}"
+          to_port: "{{ swarm_overlay_traffic_port }}"
+          group_name: "{{ swarm_security_group_name }}"
+        - proto: udp
+          from_port: "{{ swarm_overlay_traffic_port }}"
+          to_port: "{{ swarm_overlay_traffic_port }}"
           group_name: "{{ swarm_security_group_name }}"
         - proto: tcp
           from_port: 80
           to_port: 80
           cidr_ip: 0.0.0.0/0
         - proto: tcp
+          from_port: 443
+          to_port: 443
+          cidr_ip: 0.0.0.0/0
+        - proto: tcp
           from_port: 8080
           to_port: 8080
           cidr_ip: 0.0.0.0/0
       rules_egress:
-        - proto: udp
-          from_port: "{{ flanel_overlay_network_port }}"
-          to_port: "{{ flanel_overlay_network_port }}"
-          group_name: "{{ swarm_security_group_name }}"
         - proto: tcp
+          from_port: 0
+          to_port: 65535
+          cidr_ip: 0.0.0.0/0
+        - proto: udp
           from_port: 0
           to_port: 65535
           cidr_ip: 0.0.0.0/0


### PR DESCRIPTION
- fix security group outbound rules: add udp
- fix security group inbound rules: add swarm ports (Cf. https://docs.docker.com/engine/swarm/swarm-tutorial/)